### PR TITLE
Coment tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ var options={
     closeTag: "}}",
     tokens: [
         [/bold\s(.+)/, "'<b>$1</b>'"]
-    ]
+    ],
+    comentTags: {
+        open: "{{#",
+        close: "}}"
+    }
 };
 
 
@@ -52,7 +56,7 @@ The tag `include` is already implemented, allowing you to recursively load (and 
 ### Examples:
 Using the tags delimiters `{{ ... }}`
 
-* `/[Tt]itle/` - `"title"` will translate any tag of the type `{{ title }}` or `{{Title}}` into a valid `<%- title %>` ejs tag which will be rendered by ejs. Then, ejs will use yout `title` argument (wether is a variable or a function) to generate the content. 
+* `/[Tt]itle/` - `"title"` will translate any tag of the type `{{ title }}` or `{{Title}}` into a valid `<%- title %>` ejs tag which will be rendered by ejs. Then, ejs will use yout `title` argument (wether is a variable or a function) to generate the content.
 
 * `/[Tt]itle2/` - `"'title'"` will render all `{{title}}` tags into the string `"title"`, without the need of extra arguments.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var options={
     tokens: [
         [/bold\s(.+)/, "'<b>$1</b>'"]
     ],
-    comentTags: {
+    commentTags: {
         open: "{{#",
         close: "}}"
     }

--- a/app/tag_parser.js
+++ b/app/tag_parser.js
@@ -4,6 +4,14 @@ var defaultTokens = [
     [/include\s+(\S+)/i, "xejs(\"$1\",options,parentPath)"]
 ];
 
+function stripComments(content, commentTags) {
+    commentTags.open = commentTags.open || "{{#";
+    commentTags.close = commentTags.close || "}}";
+    var commentRegex = new RegExp(commentTags.open + "[\s\S]*?" + commentTags.close, "g");
+    content = content.replace(commentRegex, '');
+    return content;
+}
+
 function generateTagRegex(token, options) {
     var modifier = "g";
     if (token.ignoreCase) modifier += "i";
@@ -29,6 +37,7 @@ function replaceTags(content, tokens, options) {
         return result;
     }
 
+    content = stripComments(content, options.commentTags);
 
     for (var i = 0; i < tokens.length; i++) {
         var reg = generateTagRegex(tokens[i][0], options);

--- a/test/file4.md
+++ b/test/file4.md
@@ -1,0 +1,7 @@
+# Comment tags
+{{#Inline comment }}
+{{#Multiline
+comment }}
+{{#Comment-without-space}}
+{{# Emoji 💩 comment }}
+{{# With } part of ending tag }}

--- a/test/main.js
+++ b/test/main.js
@@ -59,4 +59,12 @@ describe("Main test", function() {
             });
         });
     });
+
+    it("Comment tags", function(done) {
+        xejs(__dirname + '/file4.md', function(err, res) {
+            assert.notOk(err);
+            assert.ok(res);
+            assert.notMatch(res, /{{#[\s\S]*?}}/);
+        });
+    });
 });


### PR DESCRIPTION
This implements a function to strip comments. (Closes #11)
The comment tags default to `{{#` and `}}` and are customizable as an `options` parameter.

I couldn't get tests to run on my windows machine unfortunately, but it should be okay as the test for this feature is quite similar to the existing ones.